### PR TITLE
Add github action to build Segment-mini container

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: Segment_mini
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Segment_mini/Dockerfile
+++ b/Segment_mini/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:20.04
+
+# Label
+LABEL org.opencontainers.image.title="fish trait segmentation"
+LABEL org.opencontainers.image.authors=" M. Maruf, T. Tabarin, J. Bradley"
+LABEL org.opencontainers.image.source="https://github.com/hdr-bgnn/BGNN-trait-segmentation"
+
+# Install some basic utilities
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    sudo \
+    git \
+    bzip2 \
+    libx11-6 \
+    wget \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create a working directory
+RUN mkdir /app
+WORKDIR /app
+
+# Create a non-root user and switch to it
+RUN adduser --disabled-password --gecos '' --shell /bin/bash user \
+ && chown -R user:user /app
+RUN echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/90-user
+USER user
+
+# All users can use /home/user as their home directory
+ENV HOME=/home/user
+RUN chmod 777 /home/user
+
+# Set up the Conda environment
+ENV CONDA_AUTO_UPDATE_CONDA=false \
+    PATH=/home/user/miniconda/bin:$PATH
+COPY env_segment_mini.yml /app/environment.yml
+RUN curl -sLo ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh \
+ && chmod +x ~/miniconda.sh \
+ && ~/miniconda.sh -b -p ~/miniconda \
+ && rm ~/miniconda.sh \
+ && conda env update -n base -f /app/environment.yml \
+ && rm /app/environment.yml \
+ && conda clean -ya
+
+WORKDIR /pipeline
+ENV TORCH_HOME=/pipeline/.cache/torch/
+
+# Download Maruf Model
+RUN gdown -O /pipeline/saved_models/ https://drive.google.com/uc?id=1HBSGXbWw5Vorj82buF-gCi6S2DpF4mFL
+# Downlaod pretrained Model, it should to build cache outside the container
+RUN wget -P /pipeline/.cache/torch/hub/checkpoints http://data.lip6.fr/cadene/pretrainedmodels/se_resnext50_32x4d-a260b3a4.pth
+
+# Setup pipeline specific scripts
+ENV PATH="/pipeline:${PATH}"
+ADD scripts/segmentation_main.py /pipeline/segmentation_main.py
+ADD scripts/helper_mini.py /pipeline/helper_mini.py
+
+# Set the default command to a usage statement
+CMD echo "Usage: segmentation_main.py <input_jpg_path> <output_png_path>"

--- a/Segment_mini/env_segment_mini.yml
+++ b/Segment_mini/env_segment_mini.yml
@@ -46,4 +46,3 @@ dependencies:
     - torchvision==0.11.3
     - tqdm==4.62.3
     - typing-extensions==4.1.1
-prefix: /home/thibault/anaconda3/envs/segment_mini

--- a/Segment_mini/scripts/segmentation_main.py
+++ b/Segment_mini/scripts/segmentation_main.py
@@ -1,4 +1,4 @@
-#!/home/user/miniconda/bin/python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Adds a GitHub action that runs when a GitHub release is created.
This action will build a Docker container using the Segment_mini
directory and push it to ghcr.io.

The Dockerfile is based on code from:
- [Segment_mini/Docker_SMP_env_v2/Dockerfile_smp_env_v2](https://github.com/hdr-bgnn/BGNN-trait-segmentation/blob/main/Segment_mini/Docker_SMP_env_v2/Dockerfile_smp_env_v2)
- [Segment_mini/Singularity_def/Segment_mini_v3.def](https://github.com/hdr-bgnn/BGNN-trait-segmentation/blob/main/Segment_mini/Singularity_def/Segment_mini_v3.def)
The Dockerfile label annotations based on:

https://github.com/opencontainers/image-spec/blob/main/annotations.md.